### PR TITLE
Warning with Elementor Page Builder

### DIFF
--- a/single.php
+++ b/single.php
@@ -117,8 +117,10 @@ get_header(); ?>
 			<?php else : ?>
 
 				<?php 
-				the_post();
-				the_content();
+				if( have_posts() ) {
+					the_post();
+					the_content();
+				}
 				?>
 
 			<?php endif; ?>

--- a/single.php
+++ b/single.php
@@ -116,7 +116,10 @@ get_header(); ?>
 
 			<?php else : ?>
 
-				<?php the_content(); ?>
+				<?php 
+				the_post();
+				the_content();
+				?>
 
 			<?php endif; ?>
 


### PR DESCRIPTION
When editing a Template in Elementor with Page Builder Theme active, there is a PHP Warning: count(): Parameter must be an array or an object that implements Countable in wp-includes/post-template.php on line 284.
Because the global variables $page, $pages are not initialized. If function the_post() is called before, then everything is OK.
My Environment: Apache, PHP 7.2, Wordpress 4.9.8, Elementor 2.2.7, Page Builder Framework 1.11.1
I thing its similar [problem with jetpack and PHP7.2](https://github.com/Automattic/jetpack/issues/8420)

![page-builder-elementor-warning](https://user-images.githubusercontent.com/7001544/47681272-52458f80-dbc9-11e8-9a2b-5e850a0a57e7.png)