### PR TITLE
prevent searchform id from appearing twice in one page by relying on class

### DIFF
--- a/assets/scss/modules/_content.scss
+++ b/assets/scss/modules/_content.scss
@@ -447,11 +447,11 @@ body {
 	padding-right: 40px;
 }
 
-#searchform {
+.searchform {
 	position: relative;
 }
 
-#searchform:before {
+.searchform:before {
 	content: "\f118";
 	right: 15px;
 	@include vertical-align($position: absolute);

--- a/searchform.php
+++ b/searchform.php
@@ -17,7 +17,7 @@ $prefix = 'searchform-';
 
 ?>
 
-<form role="search" method="get" id="searchform" class="searchform" action="<?php echo esc_url( home_url( '/' ) ); ?>">
+<form role="search" method="get" class="searchform" action="<?php echo esc_url( home_url( '/' ) ); ?>">
 	<label>
 		<span class="screen-reader-text"><?php _e( 'Search for:', 'page-builder-framework' ); ?></span>
 		<input type="search" id="<?php echo $prefix . (int) $wpbf_search_form_id++; ?>" name="s" value="" placeholder="<?php echo esc_attr( apply_filters( 'wpbf_search_placeholder', __( 'Search &hellip;', 'page-builder-framework' ) ) ); ?>" title="<?php echo esc_attr( apply_filters( 'wpbf_search_title', __( 'Press enter to search', 'page-builder-framework' ) ) ); ?>" />


### PR DESCRIPTION
I enabled the search icon in both the primary menu and the mobile menu. That resulted in two `form#searchform` elements, which is a no-no for the HTML spec and for passing an accessibility audit. 

There doesn't seem to be anything in the theme relying on that being a unique ID, so I pulled out the ID and tweaked the CSS so it'd know it's dealing with a class. It works fine on my site.