### PR TITLE
Blog Pagination: use of wrong color variable

### DIFF
--- a/inc/customizer/styles.php
+++ b/inc/customizer/styles.php
@@ -868,8 +868,8 @@ if ( $blog_pagination_background_color_active || $blog_pagination_font_color_act
 		echo sprintf( 'background: %s;', esc_attr( $blog_pagination_background_color_active ) . '!important' );
 	}
 
-	if ( $blog_pagination_background_color_next_prev ) {
-		echo sprintf( 'color: %s;', esc_attr( $blog_pagination_background_color_next_prev ) );
+	if ( $blog_pagination_font_color_active ) {
+		echo sprintf( 'color: %s;', esc_attr( $blog_pagination_font_color_active ) );
 	}
 
 	echo '}';


### PR DESCRIPTION
Use of wrong color variable for active color in blog pagination. Variable should be `$blog_pagination_font_color_active` instead of `$blog_pagination_background_color_next_prev`
I hope it is possible to change for your next version.