### PR TITLE
Patches Translation Notificaitons

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -25,6 +25,9 @@ define( 'WPBF_PREMIUM_MIN_VERSION', '2.10' );
  */
 function wpbf_theme_setup() {
 
+	// Init.
+	require_once WPBF_THEME_DIR . '/inc/init.php';
+
 	// Custom logo.
 	add_theme_support(
 		'custom-logo',
@@ -110,7 +113,7 @@ function wpbf_theme_setup() {
 	}
 
 }
-add_action( 'after_setup_theme', 'wpbf_theme_setup' );
+add_action( 'after_setup_theme', 'wpbf_theme_setup', 9 );
 
 /**
  * Theme init.
@@ -249,6 +252,3 @@ function wpbf_enqueue_admin_scripts() {
 
 }
 add_action( 'admin_enqueue_scripts', 'wpbf_enqueue_admin_scripts' );
-
-// Init.
-require_once WPBF_THEME_DIR . '/inc/init.php';


### PR DESCRIPTION
This pull request is in regard to Issue #54 

I'm able to replicate this issue.

WordPress changed the text domain loading to `after_setup_theme` in v6.7.0
https://github.com/wordpress/wordpress/blob/master/wp-includes/l10n.php#L1370

Page Builder Framework includes its init files at the bottom of `functions.php`. Without the Premium Add-on it runs a translation during load to a var
https://github.com/mapsteps/page-builder-framework/blob/master/inc/customizer/settings/settings-premium.php#L16

Then it also looks like, according to my error logs, that this error is hitting `apply_filters()` with translations throughout the Customizer Settings definitions. 

I think the easiest solution for this is to move the PBF init includes/requires inside the top `after_setup_theme` and change the PBF Premium `after_setup_theme` hook priority to load after. For me, this resolved the translation errors while keeping the same functionality, as far as I can tell so far. If the hook priorities are incorrect (i.e. default 10, pbf-premium 9), items will be missing from The Customizer.

So, this is a patch for the theme, the fix for the premium add-on would be

`inc\customizer\customizer-settings.php` Updating the `after_setup_theme` to priority 11.

Errors pointing to files:

```
PHP Notice:  Function _load_textdomain_just_in_time was called <strong>incorrectly</strong>. Translation loading for the <code>page-builder-framework</code> domain was triggered too early. This is usually an indicator for some code in the plugin or theme running too early. Translations should be loaded at the <code>init</code> action or later. Please see <a href="https://developer.wordpress.org/advanced-administration/debug/debug-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version 6.7.0.) in wp-includes\functions.php on line 6121
PHP Stack trace:
PHP   1. {main}() wp-admin\admin-ajax.php:0
PHP   2. require_once() wp-admin\admin-ajax.php:22
PHP   3. require_once() wp-load.php:50
PHP   4. require_once() wp-config.php:102
PHP   5. include() wp-settings.php:695
PHP   6. require_once() wp-content\themes\page-builder-framework\functions.php:252
PHP   7. require_once() wp-content\themes\page-builder-framework\inc\init.php:36
PHP   8. require_once() wp-content\themes\page-builder-framework\inc\customizer\customizer-settings.php:18
PHP   9. __($text = 'General', $domain = 'page-builder-framework') wp-content\themes\page-builder-framework\inc\customizer\settings\settings-general.php:16
PHP  10. translate($text = 'General', $domain = 'page-builder-framework') wp-includes\l10n.php:307
PHP  11. get_translations_for_domain($domain = 'page-builder-framework') wp-includes\l10n.php:195
PHP  12. _load_textdomain_just_in_time($domain = 'page-builder-framework') wp-includes\l10n.php:1413
PHP  13. _doing_it_wrong($function_name = '_load_textdomain_just_in_time', $message = 'Translation loading for the <code>page-builder-framework</code> domain was triggered too early. This is usually an indicator for some code in the plugin or theme running too early. Translations should be loaded at the <code>init</code> action or later.', $version = '6.7.0') wp-includes\l10n.php:1375
PHP  14. wp_trigger_error($function_name = '', $message = 'Function _load_textdomain_just_in_time was called <strong>incorrectly</strong>. Translation loading for the <code>page-builder-framework</code> domain was triggered too early. This is usually an indicator for some code in the plugin or theme running too early. Translations should be loaded at the <code>init</code> action or later. Please see <a href="https://developer.wordpress.org/advanced-administration/debug/debug-wordpress/">Debugging in WordPress</a> for more information. (This message was added in ver'..., $error_level = *uninitialized*) wp-includes\functions.php:6061
PHP  15. trigger_error($message = 'Function _load_textdomain_just_in_time was called <strong>incorrectly</strong>. Translation loading for the <code>page-builder-framework</code> domain was triggered too early. This is usually an indicator for some code in the plugin or theme running too early. Translations should be loaded at the <code>init</code> action or later. Please see <a href="https://developer.wordpress.org/advanced-administration/debug/debug-wordpress/">Debugging in WordPress</a> for more information. (This message was added in ver'..., $error_level = 1024) wp-includes\functions.php:6121

- - - - -

PHP Notice:  Function _load_textdomain_just_in_time was called <strong>incorrectly</strong>. Translation loading for the <code>wpbfpremium</code> domain was triggered too early. This is usually an indicator for some code in the plugin or theme running too early. Translations should be loaded at the <code>init</code> action or later. Please see <a href="https://developer.wordpress.org/advanced-administration/debug/debug-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version 6.7.0.) in wp-includes\functions.php on line 6121
PHP Stack trace:
PHP   1. {main}() wp-admin\admin-ajax.php:0
PHP   2. require_once() wp-admin\admin-ajax.php:22
PHP   3. require_once() wp-load.php:50
PHP   4. require_once() wp-config.php:102
PHP   5. include() wp-settings.php:695
PHP   6. require_once() wp-content\themes\page-builder-framework\functions.php:252
PHP   7. require_once() wp-content\themes\page-builder-framework\inc\init.php:36
PHP   8. require_once() wp-content\themes\page-builder-framework\inc\customizer\customizer-settings.php:19
PHP   9. apply_filters($hook_name = 'wpbf_blog_layouts', $value = ['default' => 'Default', 'beside' => 'Image Beside Post']) wp-content\themes\page-builder-framework\inc\customizer\settings\settings-blog.php:494
PHP  10. WP_Hook->apply_filters($value = ['default' => 'Default', 'beside' => 'Image Beside Post'], $args = [0 => ['default' => 'Default', 'beside' => 'Image Beside Post']]) wp-includes\plugin.php:205
PHP  11. {closure:wp-content\plugins\wpbf-premium\inc\archive-layouts.php:52-58}($blog_layouts = ['default' => 'Default', 'beside' => 'Image Beside Post']) wp-includes\class-wp-hook.php:324
PHP  12. __($text = 'Grid', $domain = 'wpbfpremium') wp-content\plugins\wpbf-premium\inc\archive-layouts.php:54
PHP  13. translate($text = 'Grid', $domain = 'wpbfpremium') wp-includes\l10n.php:307
PHP  14. get_translations_for_domain($domain = 'wpbfpremium') wp-includes\l10n.php:195
PHP  15. _load_textdomain_just_in_time($domain = 'wpbfpremium') wp-includes\l10n.php:1413
PHP  16. _doing_it_wrong($function_name = '_load_textdomain_just_in_time', $message = 'Translation loading for the <code>wpbfpremium</code> domain was triggered too early. This is usually an indicator for some code in the plugin or theme running too early. Translations should be loaded at the <code>init</code> action or later.', $version = '6.7.0') wp-includes\l10n.php:1375
PHP  17. wp_trigger_error($function_name = '', $message = 'Function _load_textdomain_just_in_time was called <strong>incorrectly</strong>. Translation loading for the <code>wpbfpremium</code> domain was triggered too early. This is usually an indicator for some code in the plugin or theme running too early. Translations should be loaded at the <code>init</code> action or later. Please see <a href="https://developer.wordpress.org/advanced-administration/debug/debug-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version 6.7.0.'..., $error_level = *uninitialized*) wp-includes\functions.php:6061
PHP  18. trigger_error($message = 'Function _load_textdomain_just_in_time was called <strong>incorrectly</strong>. Translation loading for the <code>wpbfpremium</code> domain was triggered too early. This is usually an indicator for some code in the plugin or theme running too early. Translations should be loaded at the <code>init</code> action or later. Please see <a href="https://developer.wordpress.org/advanced-administration/debug/debug-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version 6.7.0.'..., $error_level = 1024) wp-includes\functions.php:6121
```