### PR TITLE
Fix translation notice

### DIFF
--- a/inc/init.php
+++ b/inc/init.php
@@ -32,11 +32,19 @@ require_once WPBF_THEME_DIR . '/inc/helpers.php';
 // Customizer functions.
 require_once WPBF_THEME_DIR . '/inc/customizer/customizer-functions.php';
 
-// Customizer settings.
-require_once WPBF_THEME_DIR . '/inc/customizer/customizer-settings.php';
+/**
+ * Render customizer settings.
+ */
+function wpbf_do_customizer_settings() {
 
-// Init customizer.
-wpbf_customizer_init();
+	// Customizer settings.
+	require_once WPBF_THEME_DIR . '/inc/customizer/customizer-settings.php';
+
+	// Init customizer.
+	wpbf_customizer_init();
+
+}
+add_action( 'after_setup_theme', 'wpbf_do_customizer_settings' );
 
 // Output the customizer.
 wpbf_customizer_output();


### PR DESCRIPTION
### Objective:

This PR is supposed to fix following translation notiice:

>PHP Notice:  Function _load_textdomain_just_in_time was called <strong>incorrectly</strong>. Translation loading for the <code>page-builder-framework</code> domain was triggered too early. This is usually an indicator for some code in the plugin or theme running too early. Translations should be loaded at the <code>init</code> action or later. Please see <a href="https://developer.wordpress.org/advanced-administration/debug/debug-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version 6.7.0.) in D:\www\mapsteps\wp-includes\functions.php on line 6121

### Cause of the issue:

That notice happens because we have translation function (`__`) calls in `settings-*.php` files under `wp-content\themes\page-builder-framework\inc\customizer\settings` directory.

### Prove if that's the cause:

#### More detailed steps:
- Disable all plugins, make sure debug logging is enabled
- Try to comment out customer setting files require calls in `wp-content\themes\page-builder-framework\inc\customizer\customizer-settings.php` file and leave only the `settings-general.php` require call.
- Try to remove all translation function (`__`) usage in `wp-content\themes\page-builder-framework\inc\customizer\settings\settings-general.php` file.
- Refresh the frontend, there should be no notice about that translation issue.

#### Simpler step:
- Open `wp-content\themes\page-builder-framework\functions.php` file
- At the end of line, add something like `$test = __( 'Test translation issue', 'page-builder-framework' );`
- Refresh the frontend, there should be notice about that translation issue.

### How to fix

- Wrap `require_once WPBF_THEME_DIR . '/inc/customizer/customizer-settings.php';` and `wpbf_customizer_init();` inside a function
- Hook that function to `after_setup_theme` action hook.

> Note:
> This PR is written manually, not by AI :)
