### PR TITLE
Fix: Remove unnecessary echo statement in data-alt-label attribute

### DIFF
--- a/Customizer/Controls/Repeater/RepeaterControl.php
+++ b/Customizer/Controls/Repeater/RepeaterControl.php
@@ -443,7 +443,7 @@ class RepeaterControl extends BaseControl {
 	
 								<div class="actions">
 									<button type="button" class="button remove-button<# if ( ! field.default ) { #> hidden<# } #>"><?php esc_html_e( 'Remove', 'page-builder-framework' ); ?></button>
-									<button type="button" class="button upload-button" data-label=" <?php esc_attr_e( 'Add Image', 'page-builder-framework' ); ?>" data-alt-label="<?php echo esc_attr_e( 'Change Image', 'page-builder-framework' ); ?>" >
+									<button type="button" class="button upload-button" data-label=" <?php esc_attr_e( 'Add Image', 'page-builder-framework' ); ?>" data-alt-label="<?php esc_attr_e( 'Change Image', 'page-builder-framework' ); ?>" >
 										<# if ( field.default ) { #>
 											<?php esc_html_e( 'Change Image', 'page-builder-framework' ); ?>
 										<# } else { #>

--- a/Customizer/Controls/Repeater/RepeaterControl.php
+++ b/Customizer/Controls/Repeater/RepeaterControl.php
@@ -443,7 +443,7 @@ class RepeaterControl extends BaseControl {
 	
 								<div class="actions">
 									<button type="button" class="button remove-button<# if ( ! field.default ) { #> hidden<# } #>"><?php esc_html_e( 'Remove', 'page-builder-framework' ); ?></button>
-									<button type="button" class="button upload-button" data-label=" <?php esc_attr_e( 'Add Image', 'page-builder-framework' ); ?>" data-alt-label="<?php esc_attr_e( 'Change Image', 'page-builder-framework' ); ?>" >
+									<button type="button" class="button upload-button" data-label="<?php esc_attr_e( 'Add Image', 'page-builder-framework' ); ?>" data-alt-label="<?php esc_attr_e( 'Change Image', 'page-builder-framework' ); ?>" >
 										<# if ( field.default ) { #>
 											<?php esc_html_e( 'Change Image', 'page-builder-framework' ); ?>
 										<# } else { #>


### PR DESCRIPTION
**Summary**

This PR fixes an inconsistency in the button element markup where the data-alt-label attribute was using an unnecessary echo statement.

**Changes**

- **Before**: `data-alt-label="<?php echo esc_attr_e( 'Change Image', 'page-builder-framework' ); ?>"`
- **After**: `data-alt-label="<?php esc_attr_e( 'Change Image', 'page-builder-framework' ); ?>"`

**Details**

The `esc_attr_e()` function already outputs the escaped string directly, so the additional `echo` statement is redundant. This change:

- Removes unnecessary code duplication
- Maintains consistency with the `data-label` attribute format
- Prevents potential double-output issues
- Improves code clarity and maintainability

**Testing**

- Verify that the button displays the correct label text
- Confirm that the "Change Image" label appears correctly when the image upload state changes
- Check browser console for any JavaScript errors